### PR TITLE
03_SciJava.ijm: fix style of input parameter

### DIFF
--- a/Ch01_Batch_Processing_Methods_in_ImageJ/code/03_SciJava.ijm
+++ b/Ch01_Batch_Processing_Methods_in_ImageJ/code/03_SciJava.ijm
@@ -8,7 +8,7 @@
  * 
 */
 
-#@ File (label = "Input directory", style = "directory") input
+#@ File (label = "Input file", style = "open") input
 //#@ File input // = alternative
 #@ File (label = "Output directory", style = "directory") output
 #@ String (label = "File suffix", value = ".tiff") suffix


### PR DESCRIPTION
In the script code, we expect `input` to be a file (`open(input)`), not a directory.

Without this change, the script wouldn't work when run via the <kbd>Run</kbd> button, since the first input expected a directory.
