### PR TITLE
Add two more scripts collecting cell numbers

### DIFF
--- a/Ch01_Batch_Processing_Methods_in_ImageJ/code/04b_CollectWithinTable.ijm
+++ b/Ch01_Batch_Processing_Methods_in_ImageJ/code/04b_CollectWithinTable.ijm
@@ -14,32 +14,42 @@
 
 
 //create empty collector array
-collect_nNuclei = newArray();
+//collect_nNuclei = newArray();
+Table.create("Numbers");
+rowIndex = 0;
 
 //processFolder function with the collector array as output
-collect_nNuclei = processFolder(input, collect_nNuclei);
+processFolder(input);
 
 //do something with the collected values: calculate statistiics
-Array.getStatistics(collect_nNuclei, min, max, mean, stdDev);
-print("In average, there were " + mean + " +- " + stdDev + " nuclei analyzed in an image (number of images=" + collect_nNuclei.length + ")." );
+close("Results");
+selectWindow("Numbers");
+Table.update;
+Table.rename("Numbers", "Results");
+run("Summarize");
+
+//Array.getStatistics(collect_nNuclei, min, max, mean, stdDev);
+//print("In average, there were " + mean + " +- " + stdDev + " nuclei analyzed in an image (number of images=" + collect_nNuclei.length + ")." );
 
 // function to scan folders/subfolders/files to find files with correct suffix
-function processFolder(input, collect_nNuclei) {
+function processFolder(input) {
 	list = getFileList(input);
 	list = Array.sort(list);
-	
 	
 	for (i = 0; i < list.length; i++) {
 		if(File.isDirectory(input + File.separator + list[i]))
 			collect_nNuclei = processFolder(input + File.separator + list[i], collect_nNuclei);
 		if(endsWith(list[i], suffix)){
 			nNuclei = processFile(input, output, list[i]);
-			collect_nNuclei = Array.concat(collect_nNuclei , nNuclei);
-			print("The collecting array collect_nNuclei now contains: ");
-			Array.print(collect_nNuclei);
+			selectWindow("Numbers");
+			Table.set("nNuclei", rowIndex++, nNuclei);
+
+			//collect_nNuclei = Array.concat(collect_nNuclei , nNuclei);
+			//print("The collecting array collect_nNuclei now contains: ");
+			//Array.print(collect_nNuclei);
 		}
 	}
-	return collect_nNuclei;
+	//return collect_nNuclei;
 	
 
 }

--- a/Ch01_Batch_Processing_Methods_in_ImageJ/code/04c_CollectSciJava.ijm
+++ b/Ch01_Batch_Processing_Methods_in_ImageJ/code/04c_CollectSciJava.ijm
@@ -1,0 +1,57 @@
+/*
+ * Code optimized to use the Batch function of the script editor.
+ * Executes workflow for each .suffix image within the input folder. 
+ * Input, output and suffix entered by the user via GUIs using Scripting Parameters.
+ * Workflow:
+ * * Segments nuclei in channel 3, measures the area of the nuclei and gets the nuclei outlines.
+ * * Saves results, roiManager and binary image as control image.
+ * 
+*/
+
+#@ File (label = "Input file", style = "open") input
+//#@ File input // = alternative
+#@ File (label = "Output directory", style = "directory") output
+#@ String (label = "File suffix", value = ".tiff") suffix
+#@output nROIs
+
+//opening the image
+open(input);
+filename_pure = File.nameWithoutExtension;
+
+//preparations
+roiManager("reset");
+run("Clear Results");
+run("Set Scale...", "distance=0 known=0 pixel=1 unit=pixel"); //we remove the scaling
+saving_prefix = output + File.separator + filename_pure;
+
+//get the image name
+title = getTitle(); 
+
+//AIM: basic measurement: get the outlines of the nuclei (C3) and measure the area (in pixels)
+Stack.setChannel(3);
+run("Duplicate...", "title=C3_" + title); //Duplicate only C3 for further processingg
+//median filtering to smoothen the image
+run("Median...", "radius=10");
+//set an auto threshold and binarize
+setAutoThreshold("Li dark");
+setOption("BlackBackground", true);
+run("Convert to Mask");
+run("Fill Holes");
+//use the "Analyze Particles" command to get the outlines and the measurements
+run("Set Measurements...", "area display redirect=None decimal=3");
+run("Analyze Particles...", "size=1000-Infinity display exclude add");
+
+//saving
+//save the results window as a comma-separated-value file
+saveAs("results", saving_prefix + "_results.csv"); //use saveAs command to save results
+//save the isolated C3 (binary image)
+selectWindow("C3_" + title);
+saveAs("tiff", saving_prefix + "_C3.tif"); //use saveAs command to save an image
+//save the roiManager
+roiManager("save", saving_prefix + "_rois.zip");
+
+//Clean-up
+run("Close All");
+
+//get number of ROIs
+nROIs = roiManager("count");


### PR DESCRIPTION
* `04b_CollectWithinTable.ijm` illustrates minimal changes to `04_CollectWithinArray.ijm` in order to collect the results (nNuclei) in a new table.
* `04c_CollectSciJava.ijm` adds an output parameter that automatically gets collected by the SciJava batch-processor (e.g. when run using the Batch button).